### PR TITLE
Passed default database's prefix to AmberStatus class.

### DIFF
--- a/amber.module
+++ b/amber.module
@@ -176,7 +176,8 @@ function amber_get_status() {
   $status = &drupal_static(__FUNCTION__);
   if (!isset($status)) {
     $db = Database::getConnection();
-    $status = new AmberStatus(new AmberPDO($db));
+    $prefix = $db->getConnectionOptions()['prefix']['default'];
+    $status = new AmberStatus(new AmberPDO($db), $prefix);
   }
   return $status;
 }


### PR DESCRIPTION
Due to the bug, sites which are using db_prefix for their Database settings were not able to use Amber dashboard and other functionalities related to AmberStatus class.
Bug report link: https://www.drupal.org/node/2735053
